### PR TITLE
Added bamboo support

### DIFF
--- a/src/main/java/com/robrit/snad/blocks/SnadBlock.java
+++ b/src/main/java/com/robrit/snad/blocks/SnadBlock.java
@@ -8,6 +8,7 @@ import net.minecraft.tags.FluidTags;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.BonemealableBlock;
 import net.minecraft.world.level.block.FallingBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.common.IPlantable;
@@ -61,7 +62,7 @@ public class SnadBlock extends FallingBlock {
     public void tick(BlockState blockState, ServerLevel serverLevel, BlockPos blockPos, Random random) {
         final Block blockAbove = serverLevel.getBlockState(blockPos.above()).getBlock();
 
-        if (blockAbove instanceof IPlantable) {
+        if (blockAbove instanceof IPlantable || blockAbove instanceof BonemealableBlock) {
             boolean isSameBlockType = true;
             int height = 1;
 

--- a/src/main/resources/data/minecraft/tags/blocks/bamboo_plantable_on.json
+++ b/src/main/resources/data/minecraft/tags/blocks/bamboo_plantable_on.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "snad:snad",
+    "snad:red_snad"
+  ]
+}


### PR DESCRIPTION
Added snad and red_snad to bamboo_plantable_on.json and a check for BonemealableBlock in addition to IPlantable, because Bamboo is not IPlantable. If desired, the check could instead be for BambooBlock and BambooSaplingBlock.