### PR TITLE
Streamline block checks and remove deprecated function call

### DIFF
--- a/src/main/java/com/robrit/snad/blocks/SnadBlock.java
+++ b/src/main/java/com/robrit/snad/blocks/SnadBlock.java
@@ -67,11 +67,11 @@ public class SnadBlock extends FallingBlock {
 
             while (isSameBlockType) {
                 if (blockPos.above(height).getY() < serverLevel.getMaxBuildHeight()) {
-                    final Block nextBlock = serverLevel.getBlockState(blockPos.above(height)).getBlock();
+                    final BlockState nextBlockState = serverLevel.getBlockState(blockPos.above(height));
 
-                    if (nextBlock.getClass() == blockAbove.getClass()) {
+                    if (nextBlockState.is(blockAbove)) {
                         for (int growthAttempts = 0; growthAttempts < ConfigRegistry.GROWTH_SPEED.get(); growthAttempts++) {
-                            nextBlock.randomTick(serverLevel.getBlockState(blockPos.above(height)), serverLevel, blockPos.above(height), random);
+                            nextBlockState.randomTick(serverLevel, blockPos.above(height), random);
                         }
 
                         height++;

--- a/src/main/java/com/robrit/snad/blocks/SuolSnadBlock.java
+++ b/src/main/java/com/robrit/snad/blocks/SuolSnadBlock.java
@@ -41,11 +41,11 @@ public class SuolSnadBlock extends Block {
 
             while (isSameBlockType) {
                 if (blockPos.above(height).getY() < serverLevel.getMaxBuildHeight()) {
-                    final Block nextBlock = serverLevel.getBlockState(blockPos.above(height)).getBlock();
+                    final BlockState nextBlockState = serverLevel.getBlockState(blockPos.above(height));
 
-                    if (nextBlock.getClass() == blockAbove.getClass()) {
+                    if (nextBlockState.is(blockAbove)) {
                         for (int growthAttempts = 0; growthAttempts < ConfigRegistry.GROWTH_SPEED.get(); growthAttempts++) {
-                            nextBlock.randomTick(serverLevel.getBlockState(blockPos.above(height)), serverLevel, blockPos.above(height), random);
+                            nextBlockState.randomTick(serverLevel, blockPos.above(height), random);
                         }
 
                         height++;


### PR DESCRIPTION
randomTick should be called on the BlockState, not the Block.
Comparisons between blocks should not be comparing classes. Different blocks may share a class.